### PR TITLE
Bug fix

### DIFF
--- a/DL4DistancePrediction4/config.py
+++ b/DL4DistancePrediction4/config.py
@@ -136,6 +136,10 @@ def ParseAttentionMode(modelSpecs):
 		UseFC = False
 	return (UseAvg, UseMax, UseFC)
 
+def ParseESMmode(modelSpecs):
+	# To implement
+	return None
+
 def GetBoundingBoxOffset(modelSpecs):
 	if not modelSpecs.has_key('boundingBoxOffset'):
 		return None


### PR DESCRIPTION
Short summary
Method called from config that's not implemented

`RaptorX-3DModeling/DL4DistancePrediction4/FeatureUtils.py` uses the method 
`layers = config.ParseESMmode(modelSpecs)`
in line 70

Method not in config. Implement placeholder.